### PR TITLE
Create Category IDs by patching Enum

### DIFF
--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -1591,6 +1591,11 @@ public static class PiecePrefabManager
 
 	private static void Patch_PieceTable_NextCategory(PieceTable __instance)
 	{
+        if (__instance.m_pieces.Count == 0)
+        {
+            return;
+        }
+
 		if (__instance.m_useCategories && !Hud.instance.m_pieceCategoryTabs[(int)__instance.m_selectedCategory].activeSelf)
 		{
 			__instance.NextCategory();
@@ -1599,6 +1604,11 @@ public static class PiecePrefabManager
 	
 	private static void Patch_PieceTable_PrevCategory(PieceTable __instance)
 	{
+        if (__instance.m_pieces.Count == 0)
+        {
+            return;
+        }
+
 		if (__instance.m_useCategories && !Hud.instance.m_pieceCategoryTabs[(int)__instance.m_selectedCategory].activeSelf)
 		{
 			__instance.PrevCategory();

--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -1399,6 +1399,21 @@ public static class PiecePrefabManager
         __result = __result.AddRangeToArray(PieceCategories.Keys.ToArray());
     }
 
+    public static Dictionary<Piece.PieceCategory, string> GetPieceCategoriesMap()
+    {
+        var values = Enum.GetValues(typeof(Piece.PieceCategory));
+        var names = Enum.GetNames(typeof(Piece.PieceCategory));
+
+        var map = new Dictionary<Piece.PieceCategory, string>();
+
+        for (int i = 0; i < values.Length; i++)
+        {
+            map[(Piece.PieceCategory)values.GetValue(i)] = names[i];
+        }
+
+        return map;
+    }
+
 	public static Piece.PieceCategory GetCategory(string name)
 	{
         if (Enum.TryParse(name, true, out Piece.PieceCategory category))
@@ -1411,20 +1426,25 @@ public static class PiecePrefabManager
             return category;
         }
 
-        var names = Enum.GetNames(typeof(Piece.PieceCategory));
-
-        for (int i = 0; i < names.Length; ++i)
+        if (OtherPieceCategories.TryGetValue(name, out category))
         {
-	        if (names[i] == name)
-	        {
-                category = (Piece.PieceCategory)i;
-                PieceCategories[name] = category;
+            return category;
+        }
+
+        var categories = GetPieceCategoriesMap();
+
+        foreach (var categoryPair in categories)
+        {
+            if (categoryPair.Value == name)
+            {
+                category = categoryPair.Key;
+                OtherPieceCategories[name] = category;
                 return category;
             }
         }
 
         // create a new category
-        category = (Piece.PieceCategory)names.Length - 1;
+        category = (Piece.PieceCategory)categories.Count - 1;
         PieceCategories[name] = category;
         return category;
 	}

--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -1576,7 +1576,7 @@ public static class PiecePrefabManager
 
 	private static void Patch_PieceTable_NextCategory(PieceTable __instance)
 	{
-		if (__instance.m_useCategories && !CategoriesInPieceTable(__instance).Contains(__instance.m_selectedCategory))
+		if (__instance.m_useCategories && !Hud.instance.m_pieceCategoryTabs[(int)__instance.m_selectedCategory].activeSelf)
 		{
 			__instance.NextCategory();
 		}
@@ -1584,7 +1584,7 @@ public static class PiecePrefabManager
 	
 	private static void Patch_PieceTable_PrevCategory(PieceTable __instance)
 	{
-		if (__instance.m_useCategories && !CategoriesInPieceTable(__instance).Contains(__instance.m_selectedCategory))
+		if (__instance.m_useCategories && !Hud.instance.m_pieceCategoryTabs[(int)__instance.m_selectedCategory].activeSelf)
 		{
 			__instance.PrevCategory();
 		}

--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -315,7 +315,6 @@ public class BuildPiece
 						}
 						if (Hud.instance)
 						{
-							PiecePrefabManager.ClearEmptyCategories();
 							PiecePrefabManager.DrawCategoryTabs();
 						}
 					}
@@ -1429,38 +1428,7 @@ public static class PiecePrefabManager
         PieceCategories[name] = category;
         return category;
 	}
-	
-	internal static void ClearEmptyCategories()
-	{
-		HashSet<Piece.PieceCategory> seenCategories = new();
-		foreach (GameObject prefab in ZNetScene.instance.m_prefabs)
-		{
-			if (prefab.GetComponent<Piece>() is { } piece)
-			{
-				seenCategories.Add(piece.m_category);
-			}
-		}
-		
-		List<string> categoryNames = Hud.instance.m_buildCategoryNames;
-		for (int i = categoryNames.Count - 1; i >= 0; --i)
-		{
-			if (!seenCategories.Contains((Piece.PieceCategory)i))
-			{
-				categoryNames.RemoveAt(i);
-				if (ZNetScene.instance)
-				{
-					foreach (GameObject prefab in ZNetScene.instance.m_prefabs)
-					{
-						if (prefab.GetComponent<Piece>() is { } piece && (int)piece.m_category > i)
-						{	
-							piece.m_category = (Piece.PieceCategory)((int)piece.m_category - 1);
-						}
-					}
-				}
-			}
-		}
-	}
-	
+
 	internal static void DrawCategoryTabs()
     {
         var enumNames = Enum.GetNames(typeof(Piece.PieceCategory)).Where(name => name != "All").ToList();
@@ -1493,13 +1461,6 @@ public static class PiecePrefabManager
 			}
 		}
 		
-		foreach (GameObject tab in Hud.instance.m_pieceCategoryTabs.Skip(Hud.instance.m_buildCategoryNames.Count))
-		{
-			Object.Destroy(tab);
-		}
-
-		Hud.instance.m_pieceCategoryTabs = Hud.instance.m_pieceCategoryTabs.Take(Hud.instance.m_buildCategoryNames.Count).ToArray();
-
 		if (Player.m_localPlayer && Player.m_localPlayer.m_buildPieces)
 		{
 			RepositionCategories(Player.m_localPlayer.m_buildPieces);

--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -307,10 +307,7 @@ public class BuildPiece
 					{
 						if (cfg.category.Value is BuildPieceCategory.Custom)
 						{
-							if (Hud.instance)
-							{
-								piecePrefab.m_category = PiecePrefabManager.GetCategory(cfg.customCategory.Value);
-							}
+							piecePrefab.m_category = PiecePrefabManager.GetCategory(cfg.customCategory.Value);
 						}
 						else
 						{
@@ -330,7 +327,11 @@ public class BuildPiece
 				cfg.category.SettingChanged += BuildTableConfigChanged;
 				cfg.customCategory.SettingChanged += BuildTableConfigChanged;
 
-				if (cfg.category.Value != BuildPieceCategory.Custom)
+				if (cfg.category.Value is BuildPieceCategory.Custom)
+				{
+					piecePrefab.m_category = PiecePrefabManager.GetCategory(cfg.customCategory.Value);
+				}
+				else
 				{
 					piecePrefab.m_category = (Piece.PieceCategory)cfg.category.Value;
 				}
@@ -1649,21 +1650,6 @@ public static class PiecePrefabManager
 	[HarmonyPriority(Priority.VeryHigh)]
 	private static void Hud_AwakeCreateTabs()
 	{
-		foreach (BuildPiece piece in BuildPiece.registeredPieces)
-		{
-			if (BuildPiece.pieceConfigs.TryGetValue(piece, out BuildPiece.PieceConfig cfg))
-			{
-				if (cfg.category.Value == BuildPieceCategory.Custom)
-				{
-					piece.Prefab.GetComponent<Piece>().m_category = GetCategory(cfg.customCategory.Value);
-				}
-			}
-			else if (piece.Category.Category == BuildPieceCategory.Custom)
-			{
-				piece.Prefab.GetComponent<Piece>().m_category = GetCategory(piece.Category.custom);
-			}
-		}
-		
 		DrawCategoryTabs();
 	}
 

--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -1330,6 +1330,7 @@ public static class PiecePrefabManager
 
 	private static readonly List<GameObject> piecePrefabs = new();
 	private static readonly Dictionary<string, Piece.PieceCategory> PieceCategories = new();
+	private static readonly Dictionary<string, Piece.PieceCategory> OtherPieceCategories = new();
 
 	public static GameObject RegisterPrefab(
 		string assetBundleFileName,

--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -1523,7 +1523,8 @@ public static class PiecePrefabManager
 
 		HashSet<Piece.PieceCategory> visibleCategories = CategoriesInPieceTable(pieceTable);
 
-		pieceTable.m_useCategories = visibleCategories.Count > 1;
+        bool onlyMiscActive = visibleCategories.Count == 1 && visibleCategories.First() == Piece.PieceCategory.Misc;
+        pieceTable.m_useCategories = !onlyMiscActive;
 		
 		int originallyVisibleTabs = 0;
 		int visibleTabs = 0;

--- a/PieceManager/PieceManager.cs
+++ b/PieceManager/PieceManager.cs
@@ -1242,6 +1242,8 @@ public static class PiecePrefabManager
 				nameof(UpdateAvailable_Transpiler))));
 
         harmony.Patch(AccessTools.DeclaredMethod(typeof(PieceTable), nameof(PieceTable.UpdateAvailable)),
+            prefix: new HarmonyMethod(AccessTools.DeclaredMethod(typeof(PiecePrefabManager),
+                nameof(UpdateAvailable_Prefix))),
             postfix: new HarmonyMethod(AccessTools.DeclaredMethod(typeof(PiecePrefabManager),
                 nameof(UpdateAvailable_Postfix))));
 
@@ -1565,6 +1567,18 @@ public static class PiecePrefabManager
 			__instance.PrevCategory();
 		}
 	}
+
+    private static void UpdateAvailable_Prefix(PieceTable __instance)
+    {
+        if (__instance.m_availablePieces.Count > 0)
+        {
+            int missing = MaxCategory() - __instance.m_availablePieces.Count;
+            for (int i = 0; i < missing; i++)
+            {
+                __instance.m_availablePieces.Add(new List<Piece>());
+            }
+        }
+    }
 
 	private static void UpdateAvailable_Postfix(PieceTable __instance) 
     {


### PR DESCRIPTION
### Main Changes
This mainly changes the creation of `Piece.PieceCategory` from relying on the GUI Hud and instead shares newly created categories by relying on `Enum.GetValues` and `Enum.GetNames`.
This allows us to immediately assign a fixed Piece.PieceCategory in a mod's Awake.

For example, this is what `Enum.GetValues()` looks like after adding some tabs, where value is the casted PieceCategory to an int:
```
Piece.PieceCategory: Misc, value: 0
Piece.PieceCategory: Crafting, value: 1
Piece.PieceCategory: Building, value: 2
Piece.PieceCategory: Furniture, value: 3
Piece.PieceCategory: Max, value: 4
Piece.PieceCategory: All, value: 100
Piece.PieceCategory: 5, value: 5
Piece.PieceCategory: 6, value: 6
Piece.PieceCategory: 7, value: 7
Piece.PieceCategory: 8, value: 8
Piece.PieceCategory: 9, value: 9
```

As you can see, `Piece.PieceCategory.Max` and `Piece.PieceCategory.All` are still preserved here and custom categories will start to count after 5.

### Other Changes

This has also resulted in some additional changes, such as not destroying old tabs and being able to assign m_category immediately. I've tried to split all the changes into different commits to make them easier to follow.

The decision not to delete tabs was to reliably cache them. If a category was found in a mod, it's written to the `PieceCategories` dict and doesn't need to be searched again.

### Future To-Do

A follow-up change will be to catch the case where a new category reaches the Piece.PieceCategory.All category. While it doesn't sound too likely that 95 categories will be created, this could happen with a large mod pack or many custom tools. Also, with the new change of not deleting created categories, this could happen if a player tries many names in the ingame config.